### PR TITLE
Show fleet per-vehicle metrics table

### DIFF
--- a/src/data/fleet/methods.js
+++ b/src/data/fleet/methods.js
@@ -1,0 +1,279 @@
+import { formatNumber, safeDivide, toNumber } from '../../utils.js';
+
+const fleetMethods = [
+  {
+    id: 'fleet-pendulum-empty-return',
+    name:
+      'Методика расчета показателей работы группы автомобилей на маятниковом маршруте с обратным не груженым пробегом',
+    mode: 'fleet',
+    description:
+      'Расчёт показателей работы группы автомобилей на маятниковом маршруте с обратным не груженым пробегом.',
+    inputs: [
+      { name: 'payload', label: 'Грузоподъёмность автомобиля, т (q)', min: 0, step: 0.1 },
+      {
+        name: 'loadFactor',
+        label: 'Коэффициент использования грузоподъёмности (γ)',
+        min: 0,
+        max: 1,
+        step: 0.01,
+        defaultValue: 0.9,
+      },
+      { name: 'dutyTime', label: 'Время в наряде, ч (Tн)', min: 0, step: 0.1, defaultValue: 10 },
+      { name: 'loadUnloadTime', label: 'Время на погрузку и выгрузку, ч (tпв)', min: 0, step: 0.01, defaultValue: 0.2 },
+      {
+        name: 'singleOperationTime',
+        label: 'Время одной операции (погрузка или выгрузка), ч (tп)',
+        min: 0,
+        step: 0.01,
+        defaultValue: 0.1,
+      },
+      { name: 'loadedDistance', label: 'Гружёный пробег, км (lг)', min: 0, step: 0.1, defaultValue: 16 },
+      { name: 'zeroRun1', label: 'Первый нулевой пробег, км (lн1)', min: 0, step: 0.1, defaultValue: 7 },
+      { name: 'zeroRun2', label: 'Второй нулевой пробег, км (lн2)', min: 0, step: 0.1, defaultValue: 11 },
+      { name: 'emptyDistance', label: 'Холостой пробег, км (lх)', min: 0, step: 0.1, defaultValue: 16 },
+      { name: 'technicalSpeed', label: 'Среднетехническая скорость, км/ч (Vт)', min: 0, step: 0.1, defaultValue: 25 },
+    ],
+    calculate: (values) => {
+      const payload = toNumber(values.payload);
+      const loadFactor = toNumber(values.loadFactor);
+      const dutyTime = toNumber(values.dutyTime);
+      const loadUnloadTime = toNumber(values.loadUnloadTime);
+      const singleOperationTime = toNumber(values.singleOperationTime);
+      const loadedDistance = toNumber(values.loadedDistance);
+      const zeroRun1 = toNumber(values.zeroRun1);
+      const zeroRun2 = toNumber(values.zeroRun2);
+      const emptyDistance = toNumber(values.emptyDistance);
+      const technicalSpeed = toNumber(values.technicalSpeed);
+
+      const routeLength = loadedDistance + emptyDistance; // lм
+      const tripDriveTime = safeDivide(routeLength, technicalSpeed);
+      const tripTime = tripDriveTime + loadUnloadTime; // tₑₒ
+      const payloadPerTrip = payload * loadFactor; // Qₑₒ
+      const tonneKmPerTrip = payloadPerTrip * loadedDistance; // Pₑₒ
+
+      const operationTime =
+        singleOperationTime || (loadUnloadTime > 0 ? loadUnloadTime / 2 : 0); // Rₘₐₓ
+      const throughputRaw = operationTime > 0 ? safeDivide(tripTime, operationTime) : 0; // Аэ′
+      const throughput = Math.max(Math.floor(throughputRaw), 1); // Аэ
+
+      const perVehicle = [];
+      let tonnageSum = 0;
+      let tonneKmSum = 0;
+      let distanceSum = 0;
+      let actualDutySum = 0;
+
+      const essentialTripTime = safeDivide(loadedDistance, technicalSpeed) + loadUnloadTime; // tен
+
+      for (let i = 1; i <= throughput; i += 1) {
+        const availableTime = dutyTime - operationTime * (i - 1); // Tмᵢ
+        const boundedTime = Math.max(availableTime, 0);
+        const baseTripsRaw = safeDivide(boundedTime, tripTime); // Tмᵢ / tₑₒ
+        const baseTrips = Math.floor(baseTripsRaw); // [Tмᵢ / tₑₒ]
+        const remainderTime = boundedTime - baseTrips * tripTime; // ΔTнᵢ
+        const trips = remainderTime >= essentialTripTime ? Math.ceil(baseTripsRaw) : baseTrips; // Zₑᵢ
+
+        const tonnage = payloadPerTrip * trips; // Qнᵢ
+        const tonneKm = tonneKmPerTrip * trips; // Pнᵢ
+        const totalDistance = zeroRun1 + routeLength * trips + zeroRun2 - emptyDistance; // Lобщᵢ
+        const actualDutyTime = safeDivide(totalDistance, technicalSpeed) + trips * loadUnloadTime; // Tнi факт
+
+        tonnageSum += tonnage;
+        tonneKmSum += tonneKm;
+        distanceSum += totalDistance;
+        actualDutySum += actualDutyTime;
+
+        perVehicle.push({ trips, tonnage, tonneKm, totalDistance, actualDutyTime });
+      }
+
+      const perVehicleRows = perVehicle.map((item, index) => ({
+        index: index + 1,
+        trips: formatNumber(item.trips),
+        tonnage: formatNumber(item.tonnage),
+        tonneKm: formatNumber(item.tonneKm),
+        totalDistance: formatNumber(item.totalDistance),
+        actualDutyTime: formatNumber(item.actualDutyTime),
+      }));
+
+      return {
+        'Длина маршрута lм, км': formatNumber(routeLength),
+        'Время ездки tₑₒ, ч': formatNumber(tripTime),
+        'Пропускная способность Аэ′ (неокруглённо), авто': formatNumber(throughputRaw, 2),
+        'Принятое количество авто Аэ (округлено вниз), авто': throughput,
+        'Выработка за ездку Qₑₒ, т': formatNumber(payloadPerTrip),
+        'Тонно-километры за ездку Pₑₒ, ткм': formatNumber(tonneKmPerTrip),
+        'Показатели по автомобилям': {
+          type: 'table',
+          headers: [
+            'i',
+            'Число ездок Zₑᵢ, шт',
+            'Выработка Qнᵢ, т',
+            'Тонно-километры Pнᵢ, ткм',
+            'Общий пробег Lобщᵢ, км',
+            'Фактическое время в наряде Tнᵢ факт, ч',
+          ],
+          rows: perVehicleRows,
+        },
+        'Суммарная выработка Qн = Σ Qᵢ, т': formatNumber(tonnageSum),
+        'Суммарные тонно-километры Pн = Σ Pᵢ, ткм': formatNumber(tonneKmSum),
+        'Суммарный пробег Lобщ = Σ Lобщᵢ, км': formatNumber(distanceSum),
+        'Суммарное фактическое время Tн факт = Σ Tн фактᵢ, ч': formatNumber(actualDutySum),
+      };
+    },
+  },
+  {
+    id: 'fleet-shift-balance',
+    name: 'Групповое сменное задание',
+    mode: 'fleet',
+    description: 'Рассчитывает суммарные показатели группы автомобилей по средним параметрам смены.',
+    inputs: [
+      { name: 'vehicles', label: 'Количество автомобилей в группе, шт', min: 1, step: 1 },
+      { name: 'avgTrips', label: 'Среднее число ездок на автомобиль, шт', min: 0, step: 0.1 },
+      { name: 'avgPayload', label: 'Средняя масса груза за ездку, т', min: 0, step: 0.1 },
+      { name: 'routeLength', label: 'Длина маршрута, км', min: 0, step: 0.1 },
+    ],
+    calculate: (values) => {
+      const vehicles = toNumber(values.vehicles);
+      const avgTrips = toNumber(values.avgTrips);
+      const avgPayload = toNumber(values.avgPayload);
+      const routeLength = toNumber(values.routeLength);
+
+      const totalTrips = vehicles * avgTrips;
+      const totalPayload = totalTrips * avgPayload;
+      const totalDistance = totalTrips * routeLength;
+
+      return {
+        'Всего ездок за смену, шт': formatNumber(totalTrips, 1),
+        'Общий объём перевозок, т': formatNumber(totalPayload),
+        'Суммарный пробег группы, км': formatNumber(totalDistance),
+      };
+    },
+  },
+  {
+    id: 'fleet-utilization',
+    name: 'Использование парка по времени',
+    mode: 'fleet',
+    description: 'Оценка использования сменного фонда автомобилей с учётом простоев и подготовительного времени.',
+    inputs: [
+      { name: 'vehicles', label: 'Автомобилей в парке, шт', min: 1, step: 1 },
+      { name: 'shiftDuration', label: 'Длительность смены, ч', min: 0, step: 0.1 },
+      { name: 'prepTime', label: 'Подготовительно-заключительное время, ч', min: 0, step: 0.1 },
+      { name: 'downtime', label: 'Плановые простои, ч', min: 0, step: 0.1 },
+      { name: 'workingTime', label: 'Фактическое время работы, ч', min: 0, step: 0.1 },
+    ],
+    calculate: (values) => {
+      const vehicles = toNumber(values.vehicles);
+      const shiftDuration = toNumber(values.shiftDuration);
+      const prepTime = toNumber(values.prepTime);
+      const downtime = toNumber(values.downtime);
+      const workingTime = toNumber(values.workingTime);
+
+      const effectiveTime = Math.max(shiftDuration - prepTime - downtime, 0);
+      const utilization = safeDivide(workingTime, shiftDuration);
+      const readiness = safeDivide(effectiveTime, shiftDuration);
+      const vehicleHours = workingTime * vehicles;
+
+      return {
+        'Эффективное сменное время, ч': formatNumber(effectiveTime),
+        'Готовность парка (доля)': formatNumber(readiness, 3),
+        'Коэффициент использования времени': formatNumber(utilization, 3),
+        'Время работы всего парка, чел·ч': formatNumber(vehicleHours),
+      };
+    },
+  },
+  {
+    id: 'fleet-multi-route',
+    name: 'Групповая работа на нескольких плечах',
+    mode: 'fleet',
+    description: 'Балансирует объём перевозок между двумя плечами для одной группы автомобилей.',
+    inputs: [
+      { name: 'vehicles', label: 'Число автомобилей, шт', min: 1, step: 1 },
+      { name: 'payloadA', label: 'Средний груз на плече A, т', min: 0, step: 0.1 },
+      { name: 'payloadB', label: 'Средний груз на плече B, т', min: 0, step: 0.1 },
+      { name: 'distanceA', label: 'Длина плеча A, км', min: 0, step: 0.1 },
+      { name: 'distanceB', label: 'Длина плеча B, км', min: 0, step: 0.1 },
+    ],
+    calculate: (values) => {
+      const vehicles = toNumber(values.vehicles);
+      const payloadA = toNumber(values.payloadA);
+      const payloadB = toNumber(values.payloadB);
+      const distanceA = toNumber(values.distanceA);
+      const distanceB = toNumber(values.distanceB);
+
+      const averagePayload = safeDivide(payloadA + payloadB, 2);
+      const weightedDistance = safeDivide(distanceA * payloadA + distanceB * payloadB, payloadA + payloadB);
+      const totalPayload = vehicles * averagePayload;
+
+      return {
+        'Средняя загрузка на ездку, т': formatNumber(averagePayload),
+        'Условная длина плеча, км': formatNumber(weightedDistance),
+        'Суточный объём перевозок, т': formatNumber(totalPayload),
+      };
+    },
+  },
+  {
+    id: 'fleet-time-balance',
+    name: 'Баланс времени группы',
+    mode: 'fleet',
+    description: 'Определяет структуру использования времени по типам операций для автоколонны.',
+    inputs: [
+      { name: 'vehicles', label: 'Количество машин, шт', min: 1, step: 1 },
+      { name: 'drivingTime', label: 'Время в движении, ч', min: 0, step: 0.1 },
+      { name: 'serviceTime', label: 'Время погрузки/разгрузки, ч', min: 0, step: 0.1 },
+      { name: 'idleTime', label: 'Простой организационный, ч', min: 0, step: 0.1 },
+    ],
+    calculate: (values) => {
+      const vehicles = toNumber(values.vehicles);
+      const drivingTime = toNumber(values.drivingTime);
+      const serviceTime = toNumber(values.serviceTime);
+      const idleTime = toNumber(values.idleTime);
+
+      const totalTime = drivingTime + serviceTime + idleTime;
+      const drivingShare = safeDivide(drivingTime, totalTime);
+      const serviceShare = safeDivide(serviceTime, totalTime);
+      const idleShare = safeDivide(idleTime, totalTime);
+      const vehicleHours = totalTime * vehicles;
+
+      return {
+        'Суммарное время, ч': formatNumber(totalTime),
+        'В движении, доля смены': formatNumber(drivingShare, 3),
+        'На обслуживании, доля смены': formatNumber(serviceShare, 3),
+        'Простой, доля смены': formatNumber(idleShare, 3),
+        'Затраты времени группы, чел·ч': formatNumber(vehicleHours),
+      };
+    },
+  },
+  {
+    id: 'fleet-capacity',
+    name: 'Пропускная способность автоколонны',
+    mode: 'fleet',
+    description: 'Оценивает потенциальный суточный объём перевозок группы при заданной грузоподъёмности.',
+    inputs: [
+      { name: 'vehicles', label: 'Количество машин, шт', min: 1, step: 1 },
+      { name: 'payloadCapacity', label: 'Грузоподъёмность одной машины, т', min: 0, step: 0.1 },
+      { name: 'turnaroundTime', label: 'Время оборота, ч', min: 0, step: 0.1 },
+      { name: 'shiftDuration', label: 'Длительность смены, ч', min: 0, step: 0.1 },
+      { name: 'loadFactor', label: 'Коэффициент использования грузоподъёмности', min: 0, max: 1, step: 0.01 },
+    ],
+    calculate: (values) => {
+      const vehicles = toNumber(values.vehicles);
+      const payloadCapacity = toNumber(values.payloadCapacity);
+      const turnaroundTime = toNumber(values.turnaroundTime);
+      const shiftDuration = toNumber(values.shiftDuration);
+      const loadFactor = toNumber(values.loadFactor);
+
+      const tripsPerVehicle = Math.floor(safeDivide(shiftDuration, turnaroundTime));
+      const totalTrips = tripsPerVehicle * vehicles;
+      const payloadPerTrip = payloadCapacity * loadFactor;
+      const totalPayload = payloadPerTrip * totalTrips;
+
+      return {
+        'Ездок на машину за смену, шт': tripsPerVehicle,
+        'Всего ездок за смену, шт': totalTrips,
+        'Загрузка на ездку, т': formatNumber(payloadPerTrip),
+        'Сменный объём перевозок, т': formatNumber(totalPayload),
+      };
+    },
+  },
+];
+
+export { fleetMethods };

--- a/src/data/methods.js
+++ b/src/data/methods.js
@@ -1,0 +1,9 @@
+import { methods as singleMethods } from '../methods/index.js';
+import { fleetMethods } from './fleet/methods.js';
+
+const methods = [
+  ...singleMethods.map((method) => ({ ...method, mode: 'single' })),
+  ...fleetMethods,
+];
+
+export { methods };

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
-import { methods } from './methods/index.js';
+import { methods } from './data/methods.js';
 
 const app = document.getElementById('app');
 
 let currentTab = 'calculators';
 let currentMethod = methods[0];
 let lastResults = null;
+let isFleetMode = false;
 
 const shipments = [];
 const planAssignments = {};
@@ -59,10 +60,64 @@ const renderTabNavigation = () => {
   return nav;
 };
 
-const renderMethodSelector = () => {
+const renderModeToggle = () => {
+  const wrapper = createElement('div', 'mode-toggle');
+  const label = createElement('label', 'mode-toggle__label');
+  label.htmlFor = 'fleet-mode-toggle';
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = isFleetMode;
+  checkbox.id = 'fleet-mode-toggle';
+  checkbox.className = 'mode-toggle__input';
+  checkbox.addEventListener('change', () => {
+    isFleetMode = checkbox.checked;
+    const nextMethods = methods.filter((method) => method.mode === (isFleetMode ? 'fleet' : 'single'));
+    if (nextMethods.length) {
+      currentMethod = nextMethods[0];
+    }
+    lastResults = null;
+    render();
+  });
+
+  const switchTrack = createElement('span', 'mode-toggle__switch');
+  switchTrack.appendChild(createElement('span', 'mode-toggle__handle'));
+  const title = createElement('span', 'mode-toggle__title', 'Группа авто');
+
+  label.append(checkbox, switchTrack, title);
+
+  const preview = createElement('div', 'mode-toggle__preview');
+  const oppositeMode = isFleetMode ? 'single' : 'fleet';
+  const oppositeMethods = methods.filter((method) => method.mode === oppositeMode);
+  const previewTitle = createElement(
+    'div',
+    'mode-toggle__preview-title',
+    oppositeMode === 'fleet' ? 'Предпоказ: группы авто' : 'Предпоказ: 1 авто'
+  );
+  const previewList = createElement('div', 'mode-toggle__preview-list');
+  const previewItems = oppositeMethods.slice(0, 3);
+
+  previewItems.forEach((method) => {
+    previewList.appendChild(createElement('span', 'mode-toggle__preview-pill', method.name));
+  });
+
+  if (oppositeMethods.length > previewItems.length) {
+    previewList.appendChild(
+      createElement('span', 'mode-toggle__preview-pill mode-toggle__preview-pill--more', `+${
+        oppositeMethods.length - previewItems.length
+      }`)
+    );
+  }
+
+  preview.append(previewTitle, previewList);
+  wrapper.append(label, preview);
+  return wrapper;
+};
+
+const renderMethodSelector = (availableMethods) => {
   const container = createElement('div', 'method-selector');
 
-  methods.forEach((method) => {
+  availableMethods.forEach((method) => {
     const button = createElement('button');
     button.type = 'button';
     button.textContent = method.name;
@@ -72,6 +127,10 @@ const renderMethodSelector = () => {
       lastResults = null;
       render();
     });
+
+    const badge = createElement('span', `method-badge method-badge--${method.mode}`);
+    badge.title = method.mode === 'fleet' ? 'Методика для группы автомобилей' : 'Методика для одного авто';
+    button.appendChild(badge);
     container.appendChild(button);
   });
 
@@ -182,8 +241,38 @@ const renderResults = () => {
     const titleCell = document.createElement('th');
     titleCell.scope = 'row';
     titleCell.textContent = name;
+
     const valueCell = document.createElement('td');
-    valueCell.textContent = typeof value === 'number' ? value.toString() : String(value);
+
+    if (value && typeof value === 'object' && value.type === 'table') {
+      const nestedTable = document.createElement('table');
+      nestedTable.className = 'results-subtable';
+
+      const nestedThead = document.createElement('thead');
+      const headerRow = document.createElement('tr');
+      value.headers.forEach((header) => {
+        headerRow.appendChild(createElement('th', null, header));
+      });
+      nestedThead.appendChild(headerRow);
+      nestedTable.appendChild(nestedThead);
+
+      const nestedTbody = document.createElement('tbody');
+      value.rows.forEach((item) => {
+        const nestedRow = document.createElement('tr');
+        nestedRow.appendChild(createElement('td', null, String(item.index)));
+        nestedRow.appendChild(createElement('td', null, String(item.trips)));
+        nestedRow.appendChild(createElement('td', null, String(item.tonnage)));
+        nestedRow.appendChild(createElement('td', null, String(item.tonneKm)));
+        nestedRow.appendChild(createElement('td', null, String(item.totalDistance)));
+        nestedRow.appendChild(createElement('td', null, String(item.actualDutyTime)));
+        nestedTbody.appendChild(nestedRow);
+      });
+      nestedTable.appendChild(nestedTbody);
+      valueCell.appendChild(nestedTable);
+    } else {
+      valueCell.textContent = typeof value === 'number' ? value.toString() : String(value);
+    }
+
     row.append(titleCell, valueCell);
     tbody.appendChild(row);
   });
@@ -390,7 +479,17 @@ const render = () => {
 
   if (currentTab === 'calculators') {
     const calculatorsSection = createElement('section', 'calculators');
-    calculatorsSection.appendChild(renderMethodSelector());
+    const availableMethods = methods.filter(
+      (method) => method.mode === (isFleetMode ? 'fleet' : 'single'),
+    );
+
+    if (!availableMethods.some((method) => method.id === currentMethod.id)) {
+      currentMethod = availableMethods[0];
+      lastResults = null;
+    }
+
+    calculatorsSection.appendChild(renderModeToggle());
+    calculatorsSection.appendChild(renderMethodSelector(availableMethods));
     calculatorsSection.appendChild(renderDescription());
     calculatorsSection.appendChild(renderForm());
     app.appendChild(calculatorsSection);

--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,127 @@ body.dark .app {
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
 }
 
+.mode-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.mode-toggle__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+}
+
+.mode-toggle__input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.mode-toggle__switch {
+  position: relative;
+  width: 52px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.15);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.mode-toggle__handle {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 3px 10px rgba(15, 23, 42, 0.3);
+  transform: translateX(0);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.mode-toggle__input:checked + .mode-toggle__switch {
+  background: var(--primary);
+  border-color: var(--primary-dark);
+}
+
+.mode-toggle__input:checked + .mode-toggle__switch .mode-toggle__handle {
+  transform: translateX(24px);
+  background: #f8fafc;
+}
+
+.mode-toggle__title {
+  font-weight: 700;
+}
+
+.mode-toggle__preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+  border-radius: 12px;
+  min-width: 240px;
+}
+
+body.dark .mode-toggle__preview {
+  background: rgba(15, 23, 42, 0.4);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.mode-toggle__preview-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+body.dark .mode-toggle__preview-title {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.mode-toggle__preview-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.mode-toggle__preview-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(13, 110, 253, 0.12);
+  color: inherit;
+  font-size: 0.85rem;
+  line-height: 1.2;
+}
+
+body.dark .mode-toggle__preview-pill {
+  background: rgba(13, 110, 253, 0.28);
+}
+
+.mode-toggle__preview-pill--more {
+  background: rgba(15, 23, 42, 0.08);
+  color: rgba(15, 23, 42, 0.8);
+}
+
+body.dark .mode-toggle__preview-pill--more {
+  background: rgba(226, 232, 240, 0.14);
+  color: rgba(226, 232, 240, 0.9);
+}
+
 .method-selector {
   display: flex;
   flex-wrap: wrap;
@@ -83,6 +204,7 @@ body.dark .app {
 
 .method-selector button {
   flex: 1 1 260px;
+  position: relative;
   border: 2px solid transparent;
   border-radius: 14px;
   padding: 0.9rem 1rem;
@@ -107,6 +229,26 @@ body.dark .app {
   color: white;
   border-color: var(--primary-dark);
   box-shadow: 0 18px 30px rgba(13, 110, 253, 0.4);
+}
+
+.method-badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.3);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+}
+
+.method-badge--single {
+  background: linear-gradient(135deg, #64748b, #94a3b8);
+}
+
+.method-badge--fleet {
+  background: linear-gradient(135deg, #0d6efd, #4dabf7);
 }
 
 .method-description {
@@ -202,6 +344,32 @@ body.dark .results-table {
   padding: 0.75rem 1rem;
   text-align: left;
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.results-subtable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+  background: transparent;
+}
+
+.results-subtable th,
+.results-subtable td {
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+}
+
+body.dark .results-subtable th,
+body.dark .results-subtable td {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.results-subtable thead th {
+  background: rgba(13, 110, 253, 0.1);
+  font-weight: 700;
 }
 
 .results-table th {


### PR DESCRIPTION
## Summary
- align group pendulum calculator outputs with the requested summed formulas instead of averages
- keep vehicle-level metrics while reporting total tonnage, tonne-kilometres, distance, and duty time across the fleet
- present vehicle-level fleet pendulum metrics in a dedicated table with indices

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923ed749f58832ea182d7ea79d6d60e)